### PR TITLE
Added logic to only display status below the current

### DIFF
--- a/Components/Pages/Tasks.razor
+++ b/Components/Pages/Tasks.razor
@@ -39,17 +39,20 @@ else if (_tasksStaged is not null)
                         <td>@task.DateCreated</td>
                         <td>
                             <select @onchange="(e => StatusChanged(e, task))">
-                            @foreach (Data.Enums.Status type in Enum.GetValues(typeof(Data.Enums.Status)))
-                            {
-                                if (task.Status == type)
+                                @foreach (Data.Enums.Status type in Enum.GetValues(typeof(Data.Enums.Status)))
                                 {
-                                    <option value="@type" selected>@type.GetDisplayName()</option>
+                                    if (task.Status > type)
+                                        continue;
+
+                                    if (task.Status == type)
+                                    {
+                                        <option value="@type" selected>@type.GetDisplayName()</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@type">@type.GetDisplayName()</option>
+                                    }
                                 }
-                                else
-                                {
-                                    <option value="@type">@type.GetDisplayName()</option>
-                                }
-                            }
                             </select>
                         </td>
                         <td>@task.Priority</td>
@@ -60,7 +63,7 @@ else if (_tasksStaged is not null)
                     </tr>
                 }
             </tbody>
-        </table>        
+        </table>
     </div>
 }
 @if (_tasksInProgress is null)
@@ -93,17 +96,20 @@ else if (_tasksInProgress is not null)
                         <td>@task.DateCreated</td>
                         <td>
                             <select @onchange="(e => StatusChanged(e, task))">
-                            @foreach (Data.Enums.Status type in Enum.GetValues(typeof(Data.Enums.Status)))
-                            {
-                                if (task.Status == type)
+                                @foreach (Data.Enums.Status type in Enum.GetValues(typeof(Data.Enums.Status)))
                                 {
-                                    <option value="@type" selected>@type.GetDisplayName()</option>
+                                    if (task.Status > type)
+                                        continue;
+
+                                    if (task.Status == type)
+                                    {
+                                        <option value="@type" selected>@type.GetDisplayName()</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@type">@type.GetDisplayName()</option>
+                                    }
                                 }
-                                else
-                                {
-                                    <option value="@type">@type.GetDisplayName()</option>
-                                }
-                            }
                             </select>
                         </td>
                         <td>@task.Priority</td>
@@ -147,17 +153,20 @@ else if (_tasksComplete is not null)
                         <td>@task.DateCreated</td>
                         <td>
                             <select @onchange="(e => StatusChanged(e, task))">
-                            @foreach (Data.Enums.Status type in Enum.GetValues(typeof(Data.Enums.Status)))
-                            {
-                                if (task.Status == type)
+                                @foreach (Data.Enums.Status type in Enum.GetValues(typeof(Data.Enums.Status)))
                                 {
-                                    <option value="@type" selected>@type.GetDisplayName()</option>
+                                    if (task.Status > type)
+                                        continue;
+
+                                    if (task.Status == type)
+                                    {
+                                        <option value="@type" selected>@type.GetDisplayName()</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@type">@type.GetDisplayName()</option>
+                                    }
                                 }
-                                else
-                                {
-                                    <option value="@type">@type.GetDisplayName()</option>
-                                }
-                            }
                             </select>
                         </td>
                         <td>@task.Priority</td>
@@ -174,7 +183,7 @@ else if (_tasksComplete is not null)
 
 @if (ClearTasksModalOpen)
 {
-    <Modal OnClose="ClearTasksModalOnClose" 
+    <Modal OnClose="ClearTasksModalOnClose"
            Title="Clear Tasks"
            Body="Are you sure you want to clear tasks?"
            Buttons="Modal.ButtonType.DeleteCancel">
@@ -183,8 +192,8 @@ else if (_tasksComplete is not null)
 
 @inject UpdateTitleService updateTitleService
 @code {
-    #pragma warning disable CS4014
-    #pragma warning disable CS1998
+#pragma warning disable CS4014
+#pragma warning disable CS1998
     private DatabaseContext? _context;
     private Data.Models.Task[]? _tasksStaged;
     private Data.Models.Task[]? _tasksInProgress;
@@ -196,7 +205,7 @@ else if (_tasksComplete is not null)
         if (clearTasks) this.ClearTasks();
 
         this.ClearTasksModalOpen = false;
-        
+
         StateHasChanged();
     }
 

--- a/Components/Pages/Tasks.razor
+++ b/Components/Pages/Tasks.razor
@@ -278,6 +278,9 @@ else if (_tasksComplete is not null)
 
         if (Enum.TryParse<Data.Enums.Status>(e.Value?.ToString(), out var status))
         {
+            if (task.Status > status)
+                return;
+
             task.Status = status;
             _context.Tasks.Update(task);
             _context.SaveChanges();


### PR DESCRIPTION
Made a simple change to the logic that populates the options in the Status combos so that it only displays Status that are below the current Status. This is the simplest and least intrusive way I found to implement the feature. Let me know if you agree with this.